### PR TITLE
【UI実装】Mockの画面遷移の実装_食事情報管理機能

### DIFF
--- a/src/app/(dashboard)/meal/menu/page.tsx
+++ b/src/app/(dashboard)/meal/menu/page.tsx
@@ -20,7 +20,6 @@ const menuDataList: MenuData[] = [
 
 export default function MealMenuSearch() {
   const [selectedMenu, setSelectedMenu] = useState<MenuData | null>(null);
-  const [open, setOpen] = useState(false);
   const router = useRouter();
 
   const handleBackScreen = () => {
@@ -29,14 +28,13 @@ export default function MealMenuSearch() {
 
   const handleMenuDetail = (menuData: MenuData) => {
     setSelectedMenu(menuData);
-    setOpen(true);
   };
 
   const handleAddMenu = (menuData: MenuData) => {
-    router.replace("/previousPage");
+    router.replace("/meal/register");
   };
 
-  const handleCloseModal = () => setOpen(false);
+  const handleCloseModal = () => setSelectedMenu(null);
 
   return (
     <div>
@@ -51,9 +49,9 @@ export default function MealMenuSearch() {
         variant="contained"
         onClick={handleBackScreen}
       ></BaseButton>
-      {open && selectedMenu && (
+      {selectedMenu && (
         <MenuDetailModal
-          open={open}
+          open={true}
           menuData={selectedMenu}
           onAddMenuClick={handleAddMenu}
           onCloseClick={handleCloseModal}

--- a/src/app/(dashboard)/meal/page.tsx
+++ b/src/app/(dashboard)/meal/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import BaseButton from "@/components/base/BaseButton";
 import MealDetailModal from "@/components/meal/list/detail/MealDetailModal";
 import MealTable, { MealData } from "@/components/meal/list/MealTable";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -57,6 +58,14 @@ export default function MealList() {
         mealData={mealData}
         onMealElementClick={handleMealDetail}
       ></MealTable>
+      {isSelect && (
+        <BaseButton
+          className="m-[10px_0px_10px_0px]"
+          name="戻る"
+          variant="contained"
+          onClick={handleBackScreen}
+        ></BaseButton>
+      )}
       {selectedMeal && (
         <MealDetailModal
           open={true}

--- a/src/app/(dashboard)/meal/register/page.tsx
+++ b/src/app/(dashboard)/meal/register/page.tsx
@@ -1,15 +1,31 @@
 "use client";
 
 import BaseButton from "@/components/base/BaseButton";
+import BaseModal from "@/components/base/BaseModal";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function MealRegister() {
+  const [openConfirm, setOpenConfirm] = useState<boolean>(false);
+  const [openComplete, setOpenComplete] = useState<boolean>(false);
   const router = useRouter();
+
   const handleSearchMenu = () => {
     router.push(`/meal/menu`);
   };
+
   const handleSelectRegisteredMenu = () => {
     router.push(`/meal?select=true`);
+  };
+
+  const handleRegisterMeal = () => {
+    setOpenComplete(true);
+    setOpenConfirm(false);
+  };
+
+  const handleCloseCompleteModal = () => {
+    setOpenComplete(false);
+    router.replace("/meal");
   };
 
   return (
@@ -29,6 +45,32 @@ export default function MealRegister() {
           onClick={handleSelectRegisteredMenu}
         />
       </div>
+      <BaseButton
+        className="m-[10px_10px_10px_10px]"
+        name="登録"
+        variant="contained"
+        onClick={() => setOpenConfirm(true)}
+      />
+      <BaseModal
+        modalTitle={"登録情報の確認"}
+        modalDescription={
+          "入力・選択した食事情報を登録しますか？\n修正する場合は「修正」ボタンより修正を行ってください。"
+        }
+        open={openConfirm}
+        negativeButtonName={"修正"}
+        onNegativeButtonClick={() => setOpenConfirm(false)}
+        positiveButtonName={"登録"}
+        onPositiveButtonClick={handleRegisterMeal}
+        customProp={undefined}
+      ></BaseModal>
+      <BaseModal
+        modalTitle={"登録情報の登録完了"}
+        modalDescription={"食事情報の登録が完了しました。"}
+        open={openComplete}
+        negativeButtonName={"OK"}
+        onNegativeButtonClick={handleCloseCompleteModal}
+        customProp={undefined}
+      ></BaseModal>
     </div>
   );
 }

--- a/src/components/base/BaseModal.tsx
+++ b/src/components/base/BaseModal.tsx
@@ -10,30 +10,19 @@ interface BaseModalProps<T> {
   modalTitle: string;
   modalDescription: string;
   open: boolean;
-  closeButtonName: string;
-  onCloseClick?: () => void;
-  customButtonName?: string;
-  onCustomClick?: (custopProp: T) => void;
+  negativeButtonName?: string;
+  onNegativeButtonClick?: () => void;
+  positiveButtonName?: string;
+  onPositiveButtonClick?: (custopProp: T) => void;
   customProp: T;
 }
-
-const style = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: 400,
-  bgcolor: "background.paper",
-  boxShadow: 24,
-  p: 4,
-};
 
 export default function BaseModal<T>({
   modalTitle,
   modalDescription,
   open,
-  closeButtonName,
-  onCloseClick,
+  negativeButtonName,
+  onNegativeButtonClick,
   ...customButton
 }: BaseModalProps<T>) {
   return (
@@ -42,7 +31,7 @@ export default function BaseModal<T>({
         aria-labelledby="transition-modal-title"
         aria-describedby="transition-modal-description"
         open={open}
-        onClose={onCloseClick}
+        onClose={onNegativeButtonClick}
         closeAfterTransition
         slots={{ backdrop: Backdrop }}
         slotProps={{
@@ -53,7 +42,7 @@ export default function BaseModal<T>({
       >
         <div>
           <Fade in={open}>
-            <Box sx={style}>
+            <Box className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-max bg-white shadow-lg p-4 rounded-lg">
               <Typography
                 id="transition-modal-title"
                 variant="h6"
@@ -61,25 +50,31 @@ export default function BaseModal<T>({
               >
                 {modalTitle}
               </Typography>
-              <Typography id="transition-modal-description" sx={{ mt: 2 }}>
+              <Typography
+                id="transition-modal-description"
+                sx={{ mt: 2 }}
+                className="whitespace-pre-line"
+              >
                 {modalDescription}
               </Typography>
-              <div className="flex p-4">
-                {customButton.customButtonName && (
+              <div className="flex justify-center p-4">
+                {customButton.positiveButtonName && (
                   <BaseButton
-                    className="m-2"
-                    name={customButton.customButtonName}
+                    className="m-2 w-max"
+                    name={customButton.positiveButtonName}
                     variant="contained"
                     onClick={() =>
-                      customButton.onCustomClick?.(customButton.customProp)
+                      customButton.onPositiveButtonClick?.(
+                        customButton.customProp
+                      )
                     }
                   ></BaseButton>
                 )}
                 <BaseButton
-                  className="m-2"
-                  name={closeButtonName}
+                  className="m-2 w-max"
+                  name={negativeButtonName}
                   variant="contained"
-                  onClick={onCloseClick}
+                  onClick={onNegativeButtonClick}
                 ></BaseButton>
               </div>
             </Box>

--- a/src/components/meal/list/detail/MealDetailModal.tsx
+++ b/src/components/meal/list/detail/MealDetailModal.tsx
@@ -20,12 +20,12 @@ export default function MealDetailModal({
       modalTitle="食事情報"
       modalDescription="食事の詳細情報です。"
       open={open}
-      closeButtonName="閉じる"
-      onCloseClick={onCloseClick}
-      customButtonName={
+      negativeButtonName="閉じる"
+      onNegativeButtonClick={onCloseClick}
+      positiveButtonName={
         onAddMealClick ? "選択した登録済みの食事を追加" : undefined
       }
-      onCustomClick={onAddMealClick}
+      onPositiveButtonClick={onAddMealClick}
       customProp={mealData}
     />
   );

--- a/src/components/meal/search/menu/detail/MenuDetailModal.tsx
+++ b/src/components/meal/search/menu/detail/MenuDetailModal.tsx
@@ -20,10 +20,10 @@ export default function MenuDetailModal({
       modalTitle="メニュー情報"
       modalDescription="メニューの詳細情報です。"
       open={open}
-      closeButtonName="閉じる"
-      onCloseClick={onCloseClick}
-      customButtonName="選択したメニューを追加"
-      onCustomClick={onAddMenuClick}
+      negativeButtonName="閉じる"
+      onNegativeButtonClick={onCloseClick}
+      positiveButtonName="選択したメニューを追加"
+      onPositiveButtonClick={onAddMenuClick}
       customProp={menuData}
     />
   );


### PR DESCRIPTION
■issue：https://github.com/skono177/diet-management-ui/issues/1

■対応内容
* 食事情報管理機能の画面における画面遷移処理を追加
 ※内部データの受け渡しは未実装
* interface propsのリネーム